### PR TITLE
A couple of remaining updates

### DIFF
--- a/base/templates/data_v2.html
+++ b/base/templates/data_v2.html
@@ -168,9 +168,19 @@ body, html{
                         <td><strong>Haplotypes</strong></td>
                         <td>Haplotypes for isotypes were calculated and plotted as described in <a href="https://www.biorxiv.org/content/10.1101/2020.07.23.218420v2.full">Lee <i>et al.</i></a></td>
                         <td>
-                            <a href="https://storage.googleapis.com/elegansvariation.org/releases/{{ selected_release }}/haplotype/haplotype.png">PNG</a>
+                            <a href="https://storage.googleapis.com/elegansvariation.org/releases/{{ selected_release }}/haplotype/haplotype.png">haplotype.png</a>
                             <br />
-                            <a href="https://storage.googleapis.com/elegansvariation.org/releases/{{ selected_release }}/haplotype/haplotype.pdf">PDF</a>
+                            <a href="https://storage.googleapis.com/elegansvariation.org/releases/{{ selected_release }}/haplotype/haplotype.pdf">haplotype.pdf</a>
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <td><strong>Sweep haplotypes</strong></td>
+                        <td>The most frequent haplotype that covers at least 25% of the chromosome and is found on chromosome centers was determined and classified as a selective sweep. For more details, see <a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3365839/">Andersen <i>et al.<i></a> and <a href="https://www.biorxiv.org/content/10.1101/2020.07.23.218420v2.full">Lee <i>et al.</i></a>. The plot shows red (swept), gray (non-swept), and white (not classified) regions.</td>
+                        <td>
+                            <a href="https://storage.googleapis.com/elegansvariation.org/releases/{{ selected_release }}/haplotype/sweep.pdf">sweep.pdf</a>
+                            <br />
+                            <a href="https://storage.googleapis.com/elegansvariation.org/releases/{{ selected_release }}/haplotype/sweep_summary.tsv">sweep_summary.tsv</a>
                         </td>
                     </tr>
 

--- a/base/templates/data_v2.html
+++ b/base/templates/data_v2.html
@@ -194,7 +194,7 @@ body, html{
 
             <h2>Alignment (BAM)</h2>
 
-            <p>If you do not see a strain, check the <a href="#Strain-issues" role="tab" data-toggle="tab">Strain Issues</a> tab.
+            <p>Only strains with whole-genome sequencing data have BAM files for download. If you do not see a strain, check the <a href="#Strain-issues" role="tab" data-toggle="tab">Strain Issues</a> tab.
             Some strains have been flagged and removed from distribution and analysis pipelines for a variety of reasons.</p>
 
             {% set show_issues = False %}

--- a/base/templates/download_script.sh
+++ b/base/templates/download_script.sh
@@ -12,8 +12,10 @@
 {% if v2 %}
 # {{ isotype }} strains
 {% for strain in strains -%}
+{% if strain.sequenced -%}
 wget https://elegansvariation.org.s3.amazonaws.com/bam/strain/{{ strain }}.bam
 wget https://elegansvariation.org.s3.amazonaws.com/bam/strain/{{ strain }}.bam.bai
+{% endif -%}
 {% endfor -%}
 
 {%- else %}

--- a/base/templates/releases/download_tab_strain_v2.html
+++ b/base/templates/releases/download_tab_strain_v2.html
@@ -41,7 +41,9 @@
                     {% endif %}
                 </td>
                 <td>
-                    {{ strain.strain_bam_url() }}
+                    {% if strain.sequenced %}
+                        {{ strain.strain_bam_url() }}
+                    {% endif %}
                 </td>
             </tr>
             {% endif %}

--- a/base/views/strains.py
+++ b/base/views/strains.py
@@ -58,6 +58,8 @@ def strain_data_tsv():
 
     def generate():
         col_list = list(Strain.__mapper__.columns)
+        col_order = [1, 0, 3, 4, 5, 7, 8, 9, 10, 28, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 2, 6]
+        col_list[:] = [col_list[i] for i in col_order]
         header = [x.name for x in col_list]
         yield '\t'.join(header) + "\n"
         for row in query_strains(issues=False):


### PR DESCRIPTION
1. Reorder columns to be the same as google spread sheet for strain download sheet. This was done only for this download sheet generation. `ca5a4a`

2. Remove bam/bai download links for RAD-seq only strains, and modified the batch download script accordingly. `f29cf6` and `daa1b3`

3. Add section for sweep plot and summary, and renamed the haplotype download links to be consistent with sweep `6a37f2`

All changes were verified with a running instance of the website locally. 